### PR TITLE
feat: Add endpoint to retrieve top liquidity providers by poolFeat/top liquidity providers endpoint Closes #42

### DIFF
--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
+﻿import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiQuery } from '@nestjs/swagger';
 import {
   AnalyticsService,

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,6 +1,12 @@
 import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiQuery } from '@nestjs/swagger';
-import { AnalyticsService, VolumeData, ImpermanentLossData, LeaderboardEntry } from './analytics.service';
+import {
+  AnalyticsService,
+  VolumeData,
+  ImpermanentLossData,
+  LeaderboardEntry,
+  LiquidityProvider,
+} from './analytics.service';
 
 @ApiTags('Analytics')
 @Controller('api/v1/analytics')
@@ -10,7 +16,7 @@ export class AnalyticsController {
   @Get('volume')
   @ApiOperation({ summary: 'Get historical trading volume data' })
   @ApiResponse({
-    status: 200,
+    status: HttpStatus.OK,
     description: 'Successfully retrieved volume data',
     schema: {
       type: 'array',
@@ -29,22 +35,22 @@ export class AnalyticsController {
 
   @Get('impermanent-loss')
   @ApiOperation({ summary: 'Calculate impermanent loss for liquidity providers' })
-  @ApiQuery({ 
-    name: 'entryPriceRatio', 
-    type: 'number', 
+  @ApiQuery({
+    name: 'entryPriceRatio',
+    type: 'number',
     description: 'Entry price ratio of the liquidity position',
     example: 1.0,
-    required: true 
+    required: true,
   })
-  @ApiQuery({ 
-    name: 'currentPriceRatio', 
-    type: 'number', 
+  @ApiQuery({
+    name: 'currentPriceRatio',
+    type: 'number',
     description: 'Current price ratio of the liquidity position',
     example: 1.5,
-    required: true 
+    required: true,
   })
   @ApiResponse({
-    status: 200,
+    status: HttpStatus.OK,
     description: 'Successfully calculated impermanent loss',
     schema: {
       type: 'object',
@@ -81,7 +87,7 @@ export class AnalyticsController {
   @Get('leaderboard')
   @ApiOperation({ summary: 'Get top volume traders leaderboard' })
   @ApiResponse({
-    status: 200,
+    status: HttpStatus.OK,
     description: 'Successfully retrieved leaderboard data',
     schema: {
       type: 'array',
@@ -97,5 +103,38 @@ export class AnalyticsController {
   })
   getLeaderboard(): LeaderboardEntry[] {
     return this.analyticsService.generateLeaderboard();
+  }
+
+  @Get('liquidity-providers')
+  @ApiOperation({ summary: 'Get top liquidity providers by pool' })
+  @ApiQuery({
+    name: 'poolId',
+    type: 'string',
+    description: 'Filter by pool ID (optional). If omitted, returns top providers across all pools.',
+    example: 'pool-001',
+    required: false,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully retrieved top liquidity providers',
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          rank: { type: 'number', example: 1 },
+          walletAddress: { type: 'string', example: '0x742d...8b4c' },
+          liquidityUSD: { type: 'number', example: 500000 },
+          poolId: { type: 'string', example: 'pool-001' },
+          poolPair: { type: 'string', example: 'USDC/XLM' },
+          sharePercentage: { type: 'number', example: 18.5 },
+        },
+      },
+    },
+  })
+  getTopLiquidityProviders(
+    @Query('poolId') poolId?: string,
+  ): LiquidityProvider[] {
+    return this.analyticsService.getTopLiquidityProviders(poolId);
   }
 }

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+﻿import { Injectable } from '@nestjs/common';
 
 export interface VolumeData {
   date: string;
@@ -128,7 +128,6 @@ export class AnalyticsService {
 
     if (poolId) {
       providers = providers.filter((p) => p.poolId === poolId);
-      // Re-rank after filtering
       providers = providers.map((p, index) => ({ ...p, rank: index + 1 }));
     }
 

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -17,43 +17,45 @@ export interface LeaderboardEntry {
   rank: number;
 }
 
+export interface LiquidityProvider {
+  rank: number;
+  walletAddress: string;
+  liquidityUSD: number;
+  poolId: string;
+  poolPair: string;
+  sharePercentage: number;
+}
+
 @Injectable()
 export class AnalyticsService {
   generateMockVolumeData(): VolumeData[] {
     const data: VolumeData[] = [];
     const today = new Date();
-    
+
     for (let i = 6; i >= 0; i--) {
       const date = new Date(today);
       date.setDate(date.getDate() - i);
-      
-      // Generate realistic volume data between $10,000 and $500,000
+
       const baseVolume = 250000;
       const variation = Math.random() * 200000 - 100000;
       const volumeUSD = Math.round(baseVolume + variation);
-      
+
       data.push({
-        date: date.toISOString().split('T')[0], // Format as YYYY-MM-DD
+        date: date.toISOString().split('T')[0],
         volumeUSD,
       });
     }
-    
+
     return data;
   }
 
   calculateImpermanentLoss(entryPriceRatio: number, currentPriceRatio: number): ImpermanentLossData {
-    // Validate inputs
     if (entryPriceRatio <= 0 || currentPriceRatio <= 0) {
       throw new Error('Price ratios must be positive numbers');
     }
 
-    // Calculate price ratio (current/entry)
     const priceRatio = currentPriceRatio / entryPriceRatio;
-    
-    // Apply the standard IL formula: 2 * sqrt(price_ratio) / (1 + price_ratio) - 1
     const impermanentLoss = (2 * Math.sqrt(priceRatio)) / (1 + priceRatio) - 1;
-    
-    // Convert to percentage
     const impermanentLossPercentage = impermanentLoss * 100;
 
     return {
@@ -64,7 +66,6 @@ export class AnalyticsService {
   }
 
   generateLeaderboard(): LeaderboardEntry[] {
-    // Generate dummy wallet addresses (truncated for privacy)
     const dummyWallets = [
       '0x742d...8b4c',
       '0x8f3a...2d1e',
@@ -75,18 +76,62 @@ export class AnalyticsService {
       '0x2d8f...4c1e',
       '0x5a7b...9d2f',
       '0x8e1c...3a6b',
-      '0x3f9d...2e8c'
+      '0x3f9d...2e8c',
     ];
 
-    // Generate realistic trading volumes (sorted in descending order)
     const baseVolumes = [850000, 720000, 650000, 580000, 490000, 420000, 380000, 310000, 270000, 220000];
-    
+
     const leaderboard: LeaderboardEntry[] = dummyWallets.map((wallet, index) => ({
       walletAddress: wallet,
       volumeUSD: baseVolumes[index] + Math.round(Math.random() * 50000 - 25000),
-      rank: index + 1
+      rank: index + 1,
     }));
 
     return leaderboard;
+  }
+
+  getTopLiquidityProviders(poolId?: string): LiquidityProvider[] {
+    const pools = [
+      { poolId: 'pool-001', poolPair: 'USDC/XLM' },
+      { poolId: 'pool-002', poolPair: 'XLM/BTC' },
+      { poolId: 'pool-003', poolPair: 'USDC/BTC' },
+    ];
+
+    const wallets = [
+      '0x742d...8b4c',
+      '0x8f3a...2d1e',
+      '0x1a9c...5f7b',
+      '0x6e2d...9a3c',
+      '0x4b8f...1e2d',
+      '0x9c3a...7f5b',
+      '0x2d8f...4c1e',
+      '0x5a7b...9d2f',
+      '0x8e1c...3a6b',
+      '0x3f9d...2e8c',
+    ];
+
+    const baseLiquidity = [500000, 420000, 380000, 310000, 270000, 230000, 190000, 150000, 120000, 90000];
+    const totalLiquidity = baseLiquidity.reduce((sum, v) => sum + v, 0);
+
+    let providers: LiquidityProvider[] = wallets.map((wallet, index) => {
+      const pool = pools[index % pools.length];
+      const liquidityUSD = baseLiquidity[index] + Math.round(Math.random() * 20000 - 10000);
+      return {
+        rank: index + 1,
+        walletAddress: wallet,
+        liquidityUSD,
+        poolId: pool.poolId,
+        poolPair: pool.poolPair,
+        sharePercentage: parseFloat(((liquidityUSD / totalLiquidity) * 100).toFixed(2)),
+      };
+    });
+
+    if (poolId) {
+      providers = providers.filter((p) => p.poolId === poolId);
+      // Re-rank after filtering
+      providers = providers.map((p, index) => ({ ...p, rank: index + 1 }));
+    }
+
+    return providers;
   }
 }


### PR DESCRIPTION
## Summary
Adds `GET /api/v1/analytics/liquidity-providers` endpoint that returns top liquidity providers, optionally filtered by pool.

## Changes
- Added `getTopLiquidityProviders()` method to `AnalyticsService`
- Added `LiquidityProvider` interface to `AnalyticsService`
- Added `GET /api/v1/analytics/liquidity-providers` route to `AnalyticsController` with optional `?poolId=` query param
- Full Swagger documentation included

## How to test
GET /api/v1/analytics/liquidity-providers
GET /api/v1/analytics/liquidity-providers?poolId=pool-001

Closes #42