### PR TITLE
feat: Create an endpoint to fetch the historical APY of a specific pool

### DIFF
--- a/src/pools/apy-history.helper.ts
+++ b/src/pools/apy-history.helper.ts
@@ -1,5 +1,10 @@
-export interface ApyHistoryPoint {
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ApyHistoryPoint {
+  @ApiProperty({ example: '2026-04-17' })
   date: string; // YYYY-MM-DD
+
+  @ApiProperty({ example: 12.35 })
   apyPercentage: number;
 }
 
@@ -36,7 +41,7 @@ function roundTo(value: number, decimals: number): number {
 
 /**
  * Generates 7 days of deterministic mock APY history.
- * Base 10% with ±2% daily fluctuation, seeded by poolId + date.
+ * Base 12.5% with ±0.5% to ±1.5% daily fluctuation, seeded by poolId + date.
  */
 export function generateMockApyHistory(poolId: string, now: Date = new Date()): ApyHistoryPoint[] {
   const utcMidnight = new Date(Date.UTC(
@@ -47,6 +52,7 @@ export function generateMockApyHistory(poolId: string, now: Date = new Date()): 
   ));
 
   const points: ApyHistoryPoint[] = [];
+  const BASE_APY = 12.5;
 
   // Oldest -> newest (last 7 days including today)
   for (let daysAgo = 6; daysAgo >= 0; daysAgo--) {
@@ -56,8 +62,11 @@ export function generateMockApyHistory(poolId: string, now: Date = new Date()): 
     const date = toUtcDateString(d);
     const seed = hashToSeed(`${poolId}-${date}`);
     const rand = seededRandom(seed); // 0..1
-    const variability = (rand * 4) - 2; // -2..+2
-    const apyPercentage = roundTo(10 + variability, 2);
+    // Map 0..1 to ±0.5..±1.5% noise
+    const noiseRange = 0.5 + rand; // 0.5 to 1.5
+    const noiseSign = rand > 0.5 ? 1 : -1;
+    const variability = noiseSign * noiseRange;
+    const apyPercentage = roundTo(BASE_APY + variability, 2);
 
     points.push({ date, apyPercentage });
   }

--- a/src/pools/pools.controller.ts
+++ b/src/pools/pools.controller.ts
@@ -3,11 +3,6 @@ import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApyHistoryPoint, generateMockApyHistory } from './apy-history.helper';
 import { PoolIdParamDto } from './dto/pool-id-param.dto';
 
-type ApyHistoryResponse = {
-  status: 'success';
-  data: ApyHistoryPoint[];
-};
-
 @ApiTags('pools')
 @Controller('api/v1/pools')
 export class PoolsController {
@@ -18,28 +13,11 @@ export class PoolsController {
   @ApiResponse({
     status: 200,
     description: 'APY history retrieved successfully',
-    schema: {
-      type: 'object',
-      properties: {
-        status: { type: 'string', example: 'success' },
-        data: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              date: { type: 'string', example: '2026-03-29' },
-              apyPercentage: { type: 'number', example: 9.87 },
-            },
-          },
-        },
-      },
-    },
+    type: ApyHistoryPoint,
+    isArray: true,
   })
-  getApyHistory(@Param() params: PoolIdParamDto): ApyHistoryResponse {
-    return {
-      status: 'success',
-      data: generateMockApyHistory(params.poolId),
-    };
+  getApyHistory(@Param() params: PoolIdParamDto): ApyHistoryPoint[] {
+    return generateMockApyHistory(params.poolId);
   }
 }
 


### PR DESCRIPTION
 Created a GET route at /api/v1/pools/:poolId/apy-history.
 Generated an array of 7 data points, each containing a date string and an apyPercentage (e.g., 12.5%).
 Introduced slight random fluctuations in the percentages to make the dummy data look organic.
 Returned the structured JSON array with a 200 OK status.